### PR TITLE
BUGFIX: add http/https to 'internal' zone

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@ firewall_public_services:
   - http
   - https
 firewall_internal_services:
+  - http
+  - https
   - ssh
 firewall_ip_prefix_internal:
   - 10.23.0.0/16


### PR DESCRIPTION
A real-world test showed that the services `http` and `https` need to be added to the `internal` zone, as for each source network, only one zone's settings are used; zones bound to source IP ranges do not "stack" with more specific settings overriding the less specific ones (the `public` zone, however, is in our setup bound to destination network interfaces rather than source networks and *does* effectively act as a fallback for sources that don't match any other zones' source specs). This also means that all source network specs bound to zones must be *disjunct*, as unexprected results will ensue otherwise. I should add a README explaining this, but that is left to a different PR...