### PR TITLE
Add firewall configuration reset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ three zones:
 - `firewall_reset_configuration` (default `false`): If true,
   reset the firewall rules to system defaults before applying
   our changes. This is required to actually *revoke* permissions.
+  **USE WITH CAUTION**, see the section "CAVEAT EMPTOR" below!
 
 - `firewall_ip_prefix_trusted` (default is site-specific):
   A list of networks (in CIDR notation) that are assigned to
@@ -76,4 +77,7 @@ service permissions from both `internal` and `public` zones before applying
 its own changes, it will, by default, only ever *add* new permissions via
 the "prefix" and "services" variables listed above. (At this writing, there
 is no obvious way to reset individual network or service lists to empty
-with `ansible.posix.firewalld` v.1.5.4.)
+with `ansible.posix.firewalld` v.1.5.4.) **USE THIS OPTION WITH CAUTION,
+AS IT MIGHT AFFECT TOTALLY UNRELATED, BUT REQUIRED, FIREWALL SETTINGS MADE
+BY OTHER SUBSYSTEMS, SUCH AS FORWARDING RULES FOR DOCKER CONTAINERS!**
+

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ its own changes, it will, by default, only ever *add* new permissions via
 the "prefix" and "services" variables listed above. (At this writing, there
 is no obvious way to reset individual network or service lists to empty
 with `ansible.posix.firewalld` v.1.5.4.) **USE THIS OPTION WITH CAUTION,
-AS IT MIGHT AFFECT TOTALLY UNRELATED, BUT REQUIRED, FIREWALL SETTINGS MADE
-BY OTHER SUBSYSTEMS, SUCH AS FORWARDING RULES FOR DOCKER CONTAINERS!**
+AS IT RESETS THE GLOBAL STATE OF THE IP FILTER AND MIGHT WIPE TOTALLY
+UNRELATED, BUT REQUIRED, FIREWALL SETTINGS MADE BY OTHER SUBSYSTEMS,
+SUCH AS FORWARDING RULES FOR DOCKER CONTAINERS!**
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ three zones:
   firewall configuration; otherwise a manual reload is required
   to actually activate the configuration.
 
+- `firewall_reset_configuration` (default `false`): If true,
+  reset the firewall rules to system defaults before applying
+  our changes. This is required to actually *revoke* permissions.
+
 - `firewall_ip_prefix_trusted` (default is site-specific):
   A list of networks (in CIDR notation) that are assigned to
   the `trusted` zone.
@@ -65,3 +69,9 @@ want, you have to list them all explicitly, the list for `internal` does
 **not** "inherit" from that of `public`. (See the variable documentation
 above for an example.)
 
+Last not least: remember to set `firewall_reset_configuration: true` if
+you want to actually *revoke* any permissions you had previously granted via
+this playbook. While the playbook does remove well-known system default
+service permissions from both `internal` and `public` zones before applying
+its own changes, it will, by default, only ever *add* new permissions via
+the "prefix" and "services" variables listed above.

--- a/README.md
+++ b/README.md
@@ -74,4 +74,6 @@ you want to actually *revoke* any permissions you had previously granted via
 this playbook. While the playbook does remove well-known system default
 service permissions from both `internal` and `public` zones before applying
 its own changes, it will, by default, only ever *add* new permissions via
-the "prefix" and "services" variables listed above.
+the "prefix" and "services" variables listed above. (At this writing, there
+is no obvious way to reset individual network or service lists to empty
+with `ansible.posix.firewalld` v.1.5.4.)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 firewall_restart_daemon: false
+firewall_reset_configuration: false
 firewall_public_services:
   - http
   - https

--- a/tasks/osf-redhat.yml
+++ b/tasks/osf-redhat.yml
@@ -1,11 +1,16 @@
   # Set up firewalld to only allow blanket access from trusted networks
   # OMG, firewalld is such a shitty design >_>
   
-
   
   - name: svc firewalld enable & start
     tags: security
     ansible.builtin.service: name=firewalld enabled=yes state=started
+
+
+  - name: firewalld configuration reset to default
+    tags: security
+    ansible.builtin.command: "firewall-cmd --reset-to-defaults"
+    when: firewall_reset_configuration
 
 
   - name: firewalld disable default public services 


### PR DESCRIPTION
One (hopefully, for the time being) last PR for this playbook: Since `ansible.posix.firewalld` provides no way to reset network or service lists to empty, the playbook fatally ends up only ever *adding* permissions, not *revoking* them. E.g. just removing a serivce name from the whitelist for some zone and re-running the playbook will **not** block access to that service (the playbook has no way to set a value for the entire list, it can only add or remove entries via `ansible.posix.firewalld`).

To remedy this, a new playbook variable `firewall_reset_configuration` has been added, that, when set to `true` (the default is, of course, `false`) causes the playbook to run `firewall-cmd --reset-to-defaults` via `ansible.builtin.command` before applying its own changes.

As use of this option is potentially dangerous, a stern warning regarding it has been added to the README.

Apart from a possibe future implementation for Debian-based systems (which is not on the cards right now), this playbook should now hopefully be feature-complete.