### PR TITLE
Allow to add rich rules to the public zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ three zones:
 - `firewall_public_services` (default: `[http, https]`):
   The list of services whitelisted for the `public` zone.
 
+- `firewall_ip_rich_rules_public`: (default is empty list):
+  A list of rich rules to be applied to the `public` zone.
+
 
 ## CAVEAT EMPTOR
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,4 @@ firewall_ip_prefix_trusted:
   - 132.230.224.0/24
   - 10.5.153.0/24
   - 132.230.153.0/25
+firewall_ip_rich_rules_public:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,4 +20,4 @@ firewall_ip_prefix_trusted:
   - 132.230.224.0/24
   - 10.5.153.0/24
   - 132.230.153.0/25
-firewall_ip_rich_rules_public:
+firewall_ip_rich_rules_public: []

--- a/tasks/osf-redhat.yml
+++ b/tasks/osf-redhat.yml
@@ -94,6 +94,17 @@
   with_items: "{{ firewall_public_services }}"
   when: firewall_public_services | length > 0
 
+- name: firewalld rich rules for the public zone
+  tags: security
+  ansible.posix.firewalld:
+    zone: public
+    rich_rule: "{{ item }}"
+    state: enabled
+    permanent: yes
+  with_items: "{{ firewall_ip_rich_rules_public }}"
+  when: firewall_ip_rich_rules_public | length > 0
+
+
 # Activate configuration the hard way and only once it's complete...
 
 - name: svc firewalld restart


### PR DESCRIPTION
This PR adds a new config variable `firewall_ip_rich_rules_public` that can be used to add a list of rich rules to the `public` zone (the default is the empty list, of course).

This capability will be needed for a cleanup of our firewall rules that I plan to propose shortly.